### PR TITLE
[FEAT] [#19] 소비 / 지출 카테고리

### DIFF
--- a/app/src/main/java/com/psw9999/android_accountbook_18/data/repository/category/CategoryRepository.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/data/repository/category/CategoryRepository.kt
@@ -7,4 +7,8 @@ interface CategoryRepository {
 
     suspend fun getAllCategorys() : Result<List<CategoryDto>>
 
+    suspend fun saveCategory(isSpend: Boolean, title: String, color: Int)
+
+    suspend fun updateCategory(isSpend: Boolean, title: String, color: Int)
+
 }

--- a/app/src/main/java/com/psw9999/android_accountbook_18/data/repository/category/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/data/repository/category/CategoryRepositoryImpl.kt
@@ -15,4 +15,12 @@ class CategoryRepositoryImpl @Inject constructor(
     override suspend fun getAllCategorys(): Result<List<CategoryDto>>
         = categoryDataSource.getAllCategorys()
 
+    override suspend fun saveCategory(isSpend: Boolean, title: String, color: Int) {
+        categoryDataSource.saveCategorys(isSpend, title, color)
+    }
+
+    override suspend fun updateCategory(isSpend: Boolean, title: String, color: Int) {
+        TODO("Not yet implemented")
+    }
+    
 }

--- a/app/src/main/java/com/psw9999/android_accountbook_18/data/source/local/category/CategoryLocalDataSource.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/data/source/local/category/CategoryLocalDataSource.kt
@@ -1,9 +1,14 @@
 package com.psw9999.android_accountbook_18.data.source.local.category
 
+import android.content.ContentValues
+import android.util.Log
 import com.psw9999.android_accountbook_18.data.Result
 import com.psw9999.android_accountbook_18.data.db.CategoryColumns
 import com.psw9999.android_accountbook_18.data.db.DatabaseHelper
+import com.psw9999.android_accountbook_18.data.db.DatabaseHelper.Companion.CATEGORY_TABLE
+import com.psw9999.android_accountbook_18.data.db.PaymentColumns
 import com.psw9999.android_accountbook_18.data.dto.CategoryDto
+import com.psw9999.android_accountbook_18.util.toInt
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.lang.Exception
@@ -17,9 +22,8 @@ class CategoryLocalDataSource @Inject constructor(
     override suspend fun getAllCategorys(): Result<List<CategoryDto>> = withContext(ioDispatcher) {
         val rd = dataBaseHelper.readableDatabase
         val categoryList = mutableListOf<CategoryDto>()
-
+        val cursor = rd.rawQuery("SELECT * FROM $CATEGORY_TABLE", null)
         return@withContext try {
-            val cursor = rd.rawQuery("SELECT * FROM ${DatabaseHelper.CATEGORY_TABLE}", null)
             while (cursor.moveToNext()) {
                 val id = cursor.getInt(CategoryColumns.id.ordinal)
                 val isSpend = cursor.getInt(CategoryColumns.is_spend.ordinal) == 1
@@ -27,19 +31,28 @@ class CategoryLocalDataSource @Inject constructor(
                 val color = cursor.getInt(CategoryColumns.color.ordinal)
                 categoryList.add(CategoryDto(id, isSpend, name, color))
             }
-            rd.close()
+            cursor.close()
             Result.Success(categoryList)
         } catch (e: Exception) {
-            rd.close()
+            cursor.close()
             Result.Error(e)
         }
     }
 
     override suspend fun saveCategorys(isSpend: Boolean, title: String, color: Int) {
-        TODO("Not yet implemented")
+        withContext(ioDispatcher) {
+            val wd = dataBaseHelper.writableDatabase
+            val categoryValues = ContentValues().apply {
+                put(CategoryColumns.is_spend.columnName, isSpend.toInt())
+                put(CategoryColumns.title.columnName, title)
+                put(CategoryColumns.color.columnName, color)
+            }
+            wd.insert(CATEGORY_TABLE, null, categoryValues)
+        }
     }
 
     override suspend fun updatePayment(isSpend: Boolean, title: String, color: Int) {
         TODO("Not yet implemented")
     }
 }
+

--- a/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/CategoryAddFragment.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/CategoryAddFragment.kt
@@ -1,0 +1,78 @@
+package com.psw9999.android_accountbook_18.ui.categoryadd
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import com.psw9999.android_accountbook_18.R
+import com.psw9999.android_accountbook_18.databinding.FragmentCategoryAddBinding
+import com.psw9999.android_accountbook_18.ui.categoryadd.adapter.CategoryColorAdapter
+import com.psw9999.android_accountbook_18.ui.common.BaseFragment
+import com.psw9999.android_accountbook_18.ui.main.CategoryViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class CategoryAddFragment :
+    BaseFragment<FragmentCategoryAddBinding>(R.layout.fragment_category_add) {
+
+    companion object {
+        const val IS_SPEND = "isSpend"
+    }
+
+    private val categoryAddViewModel: CategoryAddViewModel by viewModels()
+    private val categoryViewModel : CategoryViewModel by activityViewModels()
+    private val categoryColorAdapter by lazy { CategoryColorAdapter(activityContext) }
+    private lateinit var categoryColorList: List<Int>
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        arguments?.let { bundle ->
+            categoryAddViewModel.setIsSpend(bundle.getBoolean(IS_SPEND, false))
+        }
+        categoryColorList =
+            if (categoryAddViewModel.isSpend.value!!) activityContext.resources.getIntArray(R.array.spend_category_array).toList()
+            else activityContext.resources.getIntArray(R.array.income_category_array).toList()
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun initViews() {
+        categoryColorAdapter.setCategoryColorList(categoryColorList)
+        with(binding) {
+            gvCategoryColor.adapter = categoryColorAdapter
+
+            gvCategoryColor.setOnItemClickListener { _, _, position, _ ->
+                categoryAddViewModel.setSelectedColorIndex(position)
+            }
+
+            edtCategoryTitle.addTextChangedListener {
+                categoryAddViewModel.setCategoryTitle(it.toString())
+            }
+
+            btnCategoryRegister.setOnClickListener {
+                CoroutineScope(Dispatchers.Main).launch {
+                    categoryViewModel.saveCategory(
+                        isSpend = categoryAddViewModel.isSpend.value!!,
+                        title = categoryAddViewModel.categoryTitle.value!!,
+                        color = categoryColorList[categoryAddViewModel.selectedColorIndex.value!!]
+                    )
+                    categoryViewModel.getAllCategory()
+                    // TODO : 프래그먼트 종료
+                }
+            }
+        }
+    }
+
+    override fun observe() {
+        binding.viewModel = categoryAddViewModel
+    }
+
+}

--- a/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/CategoryAddViewModel.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/CategoryAddViewModel.kt
@@ -1,0 +1,30 @@
+package com.psw9999.android_accountbook_18.ui.categoryadd
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class CategoryAddViewModel : ViewModel() {
+
+    private val _isSpend = MutableLiveData(false)
+    val isSpend : LiveData<Boolean> = _isSpend
+
+    private val _catergoryTitle = MutableLiveData("")
+    val categoryTitle : LiveData<String> = _catergoryTitle
+
+    private val _selectedColorIndex = MutableLiveData(0)
+    val selectedColorIndex : LiveData<Int> = _selectedColorIndex
+
+    fun setIsSpend(isSpend : Boolean) {
+        _isSpend.value = isSpend
+    }
+
+    fun setCategoryTitle(categoryTitle : String) {
+        _catergoryTitle.value = categoryTitle
+    }
+
+    fun setSelectedColorIndex(index : Int) {
+        _selectedColorIndex.value = index
+    }
+
+}

--- a/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/adapter/CategoryColorAdapter.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/ui/categoryadd/adapter/CategoryColorAdapter.kt
@@ -1,0 +1,53 @@
+package com.psw9999.android_accountbook_18.ui.categoryadd.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import com.psw9999.android_accountbook_18.databinding.ItemCategoryColorBinding
+
+class CategoryColorAdapter(
+    private val context: Context
+) : BaseAdapter() {
+
+    private var categoryColorList = listOf<Int>()
+    private var selectedColorIndex = 0
+
+    fun setCategoryColorList(categoryColorList: List<Int>) {
+        this.categoryColorList = categoryColorList
+    }
+
+    fun setSelectedColor(selectedColor: Int) {
+        if(this.selectedColorIndex != selectedColor) {
+            this.selectedColorIndex = selectedColor
+            notifyDataSetChanged()
+        }
+    }
+
+    override fun getCount(): Int = categoryColorList.size
+
+    override fun getItem(position: Int): Int = categoryColorList[position]
+
+    override fun getItemId(position: Int): Long = 0
+
+    // TODO : 개선필요 -> 터치마다 그리드 뷰 내의 모든 뷰를 다시 그려서 비효율적..
+    override fun getView(position: Int, view: View?, viewGroup: ViewGroup?): View {
+        val binding =
+            ItemCategoryColorBinding.inflate(LayoutInflater.from(context), viewGroup, false)
+        with(binding) {
+            categoryColor.setBackgroundColor(getItem(position))
+            if (position == selectedColorIndex) {
+                categoryColor.scaleX = 1F
+                categoryColor.scaleY = 1F
+            } else {
+                categoryColor.scaleX = 0.7F
+                categoryColor.scaleX = 0.7F
+            }
+            categoryColor.setOnClickListener {
+                setSelectedColor(position)
+            }
+            return root
+        }
+    }
+}

--- a/app/src/main/java/com/psw9999/android_accountbook_18/ui/main/CategoryViewModel.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/ui/main/CategoryViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psw9999.android_accountbook_18.data.Result
 import com.psw9999.android_accountbook_18.data.dto.CategoryDto
-import com.psw9999.android_accountbook_18.data.repository.CategoryRepository
+import com.psw9999.android_accountbook_18.data.repository.category.CategoryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,6 +30,12 @@ class CategoryViewModel @Inject constructor(
                     _categorys.value = emptyList()
                 }
             }
+        }
+    }
+
+    suspend fun saveCategory(isSpend : Boolean, title : String, color : Int) {
+        viewModelScope.launch {
+            repository.saveCategory(isSpend, title, color)
         }
     }
 

--- a/app/src/main/java/com/psw9999/android_accountbook_18/util/BooleanExtension.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/util/BooleanExtension.kt
@@ -1,0 +1,6 @@
+package com.psw9999.android_accountbook_18.util
+
+fun Boolean.toInt() = if (this) 1 else 0
+
+fun Int.toBoolean() = this != 0
+

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,53 @@
     <color name="off_white">#F7F6F3</color>
     <color name="white">#FFFFFF</color>
     <color name="white_50">#80FFFFFF</color>
+
+    <color name="income_category_1">#9BD182</color>
+    <color name="income_category_2">#A3CB7A</color>
+    <color name="income_category_3">#B5CC7A</color>
+    <color name="income_category_4">#CCD67A</color>
+    <color name="income_category_5">#EAE07C</color>
+    <color name="income_category_6">#EDCF65</color>
+    <color name="income_category_7">#EBC374</color>
+    <color name="income_category_8">#E1AD60</color>
+    <color name="income_category_9">#E29C4D</color>
+    <color name="income_category_10">#E39145</color>
+
+    <array name="spend_category_array">
+        <item name="spend_category_1">#4A6CC3</item>
+        <item name="spend_category_2">#2E86C7</item>
+        <item name="spend_category_3">#4CA1D3</item>
+        <item name="spend_category_4">#48C2E9</item>
+        <item name="spend_category_5">#6ED5EB</item>
+        <item name="spend_category_6">#9FE7C8</item>
+        <item name="spend_category_7">#94D3CC</item>
+        <item name="spend_category_8">#4CB8B8</item>
+        <item name="spend_category_9">#40B98D</item>
+        <item name="spend_category_10">#2FA488</item>
+        <item name="spend_category_11">#625EBA</item>
+        <item name="spend_category_12">#817DCE</item>
+        <item name="spend_category_13">#9B7DCE</item>
+        <item name="spend_category_14">#B391EB</item>
+        <item name="spend_category_15">#D092E2</item>
+        <item name="spend_category_16">#F1B4EF</item>
+        <item name="spend_category_17">#F4AEE1</item>
+        <item name="spend_category_18">#F396B8</item>
+        <item name="spend_category_19">#DC5D7B</item>
+        <item name="spend_category_20">#CB588F</item>
+    </array>
+
+    <array name="income_category_array">
+        <item name="income_category_1">#9BD182</item>
+        <item name="income_category_2">#A3CB7A</item>
+        <item name="income_category_3">#B5CC7A</item>
+        <item name="income_category_4">#CCD67A</item>
+        <item name="income_category_5">#EAE07C</item>
+        <item name="income_category_6">#EDCF65</item>
+        <item name="income_category_7">#EBC374</item>
+        <item name="income_category_8">#E1AD60</item>
+        <item name="income_category_9">#E29C4D</item>
+        <item name="income_category_10">#E39145</item>
+    </array>
+
+
 </resources>


### PR DESCRIPTION
- 소비 / 지출 카테고리 UI 작성
- 카테고리 컬러 리스트 : 그리드뷰 및 베이스 어댑터 활용하여 구현
- 설정된 이름, 소비 / 지출 타입, 컬러 값으로 데이터베이스에 저장
- 저장 완료 후 최신 데이터 불러오기