### PR TITLE
[FIX] [#30] History Select시 PaymentId, CategoryId도 가져오도록 수정 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/app/src/main/java/com/psw9999/android_accountbook_18/data/model/HistoryItem.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/data/model/HistoryItem.kt
@@ -1,13 +1,19 @@
 package com.psw9999.android_accountbook_18.data.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class HistoryItem(
     val id: Int,
     val time: String,
     val amount: Int,
     val content: String,
+    val paymentId : Int,
     val payment : String?,
-    val isSpend : Boolean,
+    val categoryId : Int,
     val category: String,
+    val isSpend : Boolean,
     val color: Int,
     var isLast : Boolean = false
-)
+) : Parcelable

--- a/app/src/main/java/com/psw9999/android_accountbook_18/data/source/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/psw9999/android_accountbook_18/data/source/local/history/HistoryLocalDataSource.kt
@@ -66,9 +66,11 @@ class HistoryLocalDataSource @Inject constructor(
                                 getString(getColumnIndexOrThrow(HistoryColumns.time.columnName)),
                                 getInt(getColumnIndexOrThrow(HistoryColumns.amount.columnName)),
                                 getString(getColumnIndexOrThrow(HistoryColumns.content.columnName)),
+                                getInt(getColumnIndexOrThrow(HistoryColumns.payment_id.columnName)),
                                 getString(getColumnIndexOrThrow(PaymentColumns.method.columnName)),
-                                getInt(getColumnIndexOrThrow(CategoryColumns.is_spend.columnName)).toBoolean(),
+                                getInt(getColumnIndexOrThrow(HistoryColumns.category_id.columnName)),
                                 getString(getColumnIndexOrThrow(CategoryColumns.title.columnName)),
+                                getInt(getColumnIndexOrThrow(CategoryColumns.is_spend.columnName)).toBoolean(),
                                 getInt(getColumnIndexOrThrow(CategoryColumns.color.columnName))
                             )
                         )


### PR DESCRIPTION
- #30 
- 1.  Parcelize로 HistoryItem 직렬화 적용
- 2. HistoryItem에 PaymentId와 CategoryId 추가
- 3. getMonthHistory시 PaymentId와 CategoryId도 함께 저장하도록 수정